### PR TITLE
feat: support all hardhat-deploy minor release

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "hardhat": "^2.0.0",
-    "hardhat-deploy": "^0.11.10"
+    "hardhat-deploy": "0.x"
   },
   "scripts": {
     "prepare": "node ./.setup.js",


### PR DESCRIPTION
Currently, the latest `hardhat-deploy`'s version is 0.14.0 which is incompatible with this package. 